### PR TITLE
refactor user account deletion test

### DIFF
--- a/pkg/controller/useraccount/useraccount_controller.go
+++ b/pkg/controller/useraccount/useraccount_controller.go
@@ -272,11 +272,13 @@ func (r *ReconcileUserAccount) finalizer(logger logr.Logger, userAcc *toolchainv
 		return false, err
 	}
 
+	logger.Info("deleting the associated identity resource")
 	// Delete Identity associated with UserAccount
 	if err := r.client.Delete(context.TODO(), identity); err != nil {
 		return true, err
 	}
 
+	logger.Info("deleting the associated user resource")
 	// Delete User associated with UserAccount
 	if err := r.client.Delete(context.TODO(), user); err != nil {
 		return true, err

--- a/pkg/controller/useraccount/useraccount_controller_test.go
+++ b/pkg/controller/useraccount/useraccount_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
@@ -330,50 +331,53 @@ func TestReconcile(t *testing.T) {
 
 	// Delete useraccount and ensure related resources are also removed
 	t.Run("delete useraccount removes subsequent resources", func(t *testing.T) {
-		reconcile := func(r *ReconcileUserAccount, req reconcile.Request) {
-			//when
-			res, err := r.Reconcile(req)
+		// given
+		userAcc := newUserAccount(username, userID)
+		r, req, _ := prepareReconcile(t, username, userAcc, preexistingUser, preexistingIdentity)
 
-			//then
+		//when
+		res, err := r.Reconcile(req)
+
+		//then
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+
+		// Check the created user
+		user := &userv1.User{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: userAcc.Name}, user)
+		require.NoError(t, err)
+		assert.Equal(t, userAcc.Name, user.Name)
+
+		// Check the user identity mapping
+		user.UID = preexistingUser.UID // we have to set UID for the obtained user because the fake client doesn't set it
+		checkMapping(t, user, preexistingIdentity)
+
+		// Check the created/updated identity
+		identity := &userv1.Identity{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: ToIdentityName(userAcc.Spec.UserID)}, identity)
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("%s:%s", config.GetIdP(), userAcc.Spec.UserID), identity.Name)
+
+		// Check the user identity mapping
+		checkMapping(t, preexistingUser, identity)
+
+		userAcc.DeletionTimestamp = &metav1.Time{time.Now()} //nolint: govet
+		err = r.client.Update(context.TODO(), userAcc)
+		require.NoError(t, err)
+		res, err = r.Reconcile(req)
+		require.NoError(t, err)
+		if res.Requeue {
+			res, err = r.Reconcile(req)
 			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
-
-			// Check the created user
-			user := &userv1.User{}
-			err = r.client.Get(context.TODO(), types.NamespacedName{Name: userAcc.Name}, user)
-			require.NoError(t, err)
-			assert.Equal(t, userAcc.Name, user.Name)
-
-			// Check the user identity mapping
-			user.UID = preexistingUser.UID // we have to set UID for the obtained user because the fake client doesn't set it
-			checkMapping(t, user, preexistingIdentity)
-
-			// Check the created/updated identity
-			identity := &userv1.Identity{}
-			err = r.client.Get(context.TODO(), types.NamespacedName{Name: ToIdentityName(userAcc.Spec.UserID)}, identity)
-			require.NoError(t, err)
-			assert.Equal(t, fmt.Sprintf("%s:%s", config.GetIdP(), userAcc.Spec.UserID), identity.Name)
-
-			// Check the user identity mapping
-			checkMapping(t, preexistingUser, identity)
-
-			err = r.client.Delete(context.TODO(), userAcc)
-			require.NoError(t, err)
-
-			err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: req.Namespace, Name: userAcc.Name}, userAcc)
-			require.Error(t, err)
-
-			err = r.client.Get(context.TODO(), types.NamespacedName{Name: userAcc.Name}, user)
-			require.Error(t, err)
-
-			err = r.client.Get(context.TODO(), types.NamespacedName{Name: ToIdentityName(userAcc.Spec.UserID)}, identity)
-			require.Error(t, err)
 		}
+		// check that the associated user and identity resources have been deleted
+		// when reconciling the useraccount with a deletion timestamp
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: userAcc.Name}, user)
+		require.Error(t, err)
 
-		t.Run("create", func(t *testing.T) {
-			r, req, _ := prepareReconcile(t, username, userAcc, preexistingUser)
-			reconcile(r, req)
-		})
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: ToIdentityName(userAcc.Spec.UserID)}, identity)
+		require.Error(t, err)
+
 	})
 }
 


### PR DESCRIPTION
- mark the useraccount as deleted by setting a
`deletionTimestamp` and updating it in the fake client
- explicitly call the `Reconcile` method of the controller
- check that the associated resources (user and identity)
were deleted in the fake client

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>